### PR TITLE
bug: export IconService

### DIFF
--- a/projects/iconify/src/public-api.ts
+++ b/projects/iconify/src/public-api.ts
@@ -6,3 +6,4 @@ export * from './lib/icon.directive';
 export * from './lib/icon.module';
 export * from './lib/icon.interface';
 export * from './lib/icon-props.interface';
+export * from './lib/icon.service';


### PR DESCRIPTION
IconService is currently not exported, making it impossible to register icons.